### PR TITLE
Fix: use result of 2nd run subtitleSelection ( word exists in )

### DIFF
--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/Actions.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/Actions.java
@@ -550,7 +550,7 @@ public class Actions {
         if (equal && quality.equalsIgnoreCase(subtitle.getQuality())) return i;
         if (!equal) {
           for (String q : quality.split(" ")) {
-            if (subtitle.getQuality().contains(q)) return i;
+            if (subtitle.getQuality().toLowerCase().contains(q.toLowerCase())) return i;
           }
         }
       }

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/Actions.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/Actions.java
@@ -525,6 +525,7 @@ public class Actions {
     Logger.instance.trace("Actions", "getAutomaticSubtitleSelection",
         "Second run, using word exists in");
     result = qualityRuleSelectionCompare(matchingSubs, false);
+    if (result > -1) return result;
 
     if (settings.isOptionsNoRuleMatchTakeFirst()) {
       Logger.instance.debug("getAutomaticSubtitleSelection: Using taking first rule");


### PR DESCRIPTION
For #4 it was decided that if the qualityfilter wasn't matched, we would try a second attempt but per keyword.

Example:
Quality = "This version works with ACME 720p";
QualityFilter = "hdtv 720p"

Normally this wouldn't be matched by the filter but since 9c9ea7ebaed6e8d56c1f6863cce6c3c93ad531c6 it does.

( Quality contains "720p", hence it matches )

However, the result of the 2nd run was never used.
Also made it case insensitive