### PR TITLE
Filter subs before showing when using Automatic Selection.

### DIFF
--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/extra/SearchPanel.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/extra/SearchPanel.java
@@ -65,8 +65,8 @@ public class SearchPanel extends JPanel {
       public void actionPerformed(ActionEvent e) {
         final DefaultTableModel model = (DefaultTableModel) resultTable.getModel();
         for (int i = 0; i < model.getRowCount(); i++) {
-          final int numFound =
-              (Integer) model.getValueAt(i, resultTable.getColumnIdByName(SearchColumnName.FOUND));
+          String found = (String) model.getValueAt(i, resultTable.getColumnIdByName(SearchColumnName.FOUND));
+          final int numFound = Integer.parseInt(found.split("/")[0]);
           model.setValueAt(false, i, resultTable.getColumnIdByName(SearchColumnName.SELECT));
           if (numFound > 0) {
             model.setValueAt(true, i, resultTable.getColumnIdByName(SearchColumnName.SELECT));

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/extra/table/SearchColumnName.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/extra/table/SearchColumnName.java
@@ -2,7 +2,7 @@ package org.lodder.subtools.multisubdownloader.gui.extra.table;
 
 public enum SearchColumnName {
   SERIE("Serie/Movie", String.class, false), FILENAME("Bestandsnaam", String.class, false), FOUND(
-      "# Gevonden", Integer.class, false), SELECT("Selecteer", Boolean.class, true), OBJECT(
+      "# Gevonden/Totaal", String.class, false), SELECT("Selecteer", Boolean.class, true), OBJECT(
       "Episode Object", Object.class, false), SEASON("Seizoen", String.class, false), EPISODE(
       "Aflevering", String.class, false), TYPE("Type", String.class, false), TITLE("Titel",
       String.class, false), SOURCE("Source", String.class, false);

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/extra/table/VideoTableModel.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/extra/table/VideoTableModel.java
@@ -125,7 +125,7 @@ public class VideoTableModel extends DefaultTableModel {
         } else if (SearchColumnName.FILENAME.getColumnName().equals(columnName)) {
           row[i] = videoFile.getFilename();
         } else if (SearchColumnName.FOUND.getColumnName().equals(columnName)) {
-          row[i] = videoFile.getMatchingSubs().size();
+          row[i] = "" + videoFile.getFilteredSubs().size() + "/" + videoFile.getMatchingSubs().size();
         } else if (SearchColumnName.SELECT.getColumnName().equals(columnName)) {
           row[i] = false;
         } else if (SearchColumnName.OBJECT.getColumnName().equals(columnName)) {

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/workers/SearchFileWorker.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/workers/SearchFileWorker.java
@@ -26,11 +26,13 @@ public class SearchFileWorker extends SwingWorker<List<VideoFile>, String> {
   private VideoTable table;
   private boolean forceSubtitleOverwrite;
   private List<VideoFile> list;
+  private SearchWorkerFilter filter;
 
   public SearchFileWorker(VideoTable table, Settings settings) {
     this.table = table;
     this.settings = settings;
     actions = new Actions(settings, false);
+    filter = new SearchWorkerFilter(settings);
   }
 
   @SuppressWarnings("serial")
@@ -72,7 +74,10 @@ public class SearchFileWorker extends SwingWorker<List<VideoFile>, String> {
         publish(files.get(i).getName());
         try {
           VideoFile videoFile = VideoFileFactory.get(files.get(i), dir, settings, languagecode);
-          if (videoFile != null) list.add(videoFile);
+          if (videoFile != null) {
+            filter.filter(videoFile);
+            list.add(videoFile);
+          }
         } catch (Exception e) {
           Logger.instance.log("Error processing file " + Logger.stack2String(e));
           if (settings.isOptionsStopOnSearchError())

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/workers/SearchNameWorker.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/workers/SearchNameWorker.java
@@ -28,11 +28,13 @@ public class SearchNameWorker extends SwingWorker<List<Subtitle>, String> {
   private String videoText, languagecode, quality;
   private int season, episode;
   private VideoSearchType videoSearchTypeChoice;
+  private SearchWorkerFilter filter;
 
   public SearchNameWorker(VideoTable table, Settings settings) {
     this.table = table;
     this.settings = settings;
     tsc = new NameSearchControl(settings);
+    filter = new SearchWorkerFilter(settings);
   }
 
   public void setParameters(VideoSearchType videoTypeChoice, String videoText, int season,
@@ -61,7 +63,8 @@ public class SearchNameWorker extends SwingWorker<List<Subtitle>, String> {
       VideoFile videoFile =
           VideoFileFactory.get(new File(videoText), new File("/"), settings, languagecode);
       if (videoFile != null) {
-        l = videoFile.getMatchingSubs();
+        filter.filter(videoFile);
+        l = videoFile.getFilteredSubs();
       }
     }
     return l;

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/workers/SearchWorkerFilter.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/gui/workers/SearchWorkerFilter.java
@@ -1,0 +1,48 @@
+package org.lodder.subtools.multisubdownloader.gui.workers;
+
+import java.util.ArrayList;
+import org.lodder.subtools.multisubdownloader.lib.SubtitleSelectionCLI;
+import org.lodder.subtools.multisubdownloader.settings.model.Settings;
+import org.lodder.subtools.sublibrary.logging.Logger;
+import org.lodder.subtools.sublibrary.model.Subtitle;
+import org.lodder.subtools.sublibrary.model.VideoFile;
+
+public class SearchWorkerFilter {
+
+  private Settings settings;
+
+  public SearchWorkerFilter(Settings settings) {
+    this.settings = settings;
+  }
+
+  private void automaticSelectionFilter(VideoFile videoFile) {
+    Logger.instance.debug("getSubtitlesFiltered: Automatic download selection detected.");
+    SubtitleSelectionCLI subtitleSelection = new SubtitleSelectionCLI(settings, videoFile);
+
+    int index = subtitleSelection.getAutomatic();
+
+    if (index >= 0) {
+      Logger.instance.debug("getSubtitlesFiltered: Automatic selection made. index: " + index);
+      Subtitle subtitle = videoFile.getFilteredSubs().get(index);
+
+      // empty the filtered list
+      videoFile.getFilteredSubs().clear();
+
+      videoFile.getFilteredSubs().add(subtitle);
+    } else {
+      // If no selection could be made, just empty the list
+      videoFile.getFilteredSubs().clear();
+    }
+  }
+
+  public void filter(VideoFile videoFile) {
+    if (videoFile.getMatchingSubs().size() <= 0)
+      return;
+
+    // We start by allowing all subtitles
+    videoFile.setFilteredSubs(new ArrayList<Subtitle>(videoFile.getMatchingSubs()));
+
+    if (settings.isOptionsAutomaticDownloadSelection())
+      automaticSelectionFilter(videoFile);
+  }
+}

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/SubtitleSelection.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/SubtitleSelection.java
@@ -52,7 +52,7 @@ public abstract class SubtitleSelection {
 
   private int teamCompare(boolean equal) {
     Logger.instance.trace("SubtitleSelection", "teamCompare", "equal: " + equal);
-    List<Subtitle> matchingSubs = videoFile.getMatchingSubs();
+    List<Subtitle> matchingSubs = videoFile.getFilteredSubs();
     Subtitle subtitle;
     Logger.instance.trace("teamCompare", "teamCompare", "videofile team: " + videoFile.getTeam());
     for (int i = 0; i < matchingSubs.size(); i++) {
@@ -73,7 +73,7 @@ public abstract class SubtitleSelection {
 
   private int qualityRuleSelectionCompare(boolean equal) {
     Logger.instance.trace("SubtitleSelection", "qualityRuleSelectionCompare", "equal: " + equal);
-    List<Subtitle> matchingSubs = videoFile.getMatchingSubs();
+    List<Subtitle> matchingSubs = videoFile.getFilteredSubs();
     Subtitle subtitle;
     for (String quality : settings.getQualityRuleList()) {
       Logger.instance.trace("SubtitleSelection", "qualityRuleSelectionCompare",

--- a/SubLibrary/src/main/java/org/lodder/subtools/sublibrary/model/VideoFile.java
+++ b/SubLibrary/src/main/java/org/lodder/subtools/sublibrary/model/VideoFile.java
@@ -8,6 +8,7 @@ import java.util.List;
 public class VideoFile extends Video{
 
     private List<Subtitle> matchingSubs;
+    private List<Subtitle> filteredSubs;
     private File path;
     private String extension;
     private String filename;
@@ -19,6 +20,7 @@ public class VideoFile extends Video{
         this.setVideoType(videoType);
         extension = "";
         matchingSubs = new ArrayList<Subtitle>();
+        filteredSubs = new ArrayList<Subtitle>();
         filename = "";
         path = new File("");
         quality = "";
@@ -47,8 +49,16 @@ public class VideoFile extends Video{
         return matchingSubs;
     }
 
+    public List<Subtitle> getFilteredSubs() {
+        return filteredSubs;
+    }
+
     public void setMatchingSubs(List<Subtitle> matchingSubs) {
         this.matchingSubs = matchingSubs;
+    }
+
+    public void setFilteredSubs(List<Subtitle> filteredSubs) {
+        this.filteredSubs = filteredSubs;
     }
 
     public String getFilename() {


### PR DESCRIPTION
This pull-requests filters the found subtitles before showing them when using the Automatic Selection filter.

Fixed some concerns raised in #16.
- Spread across multiple commits to increase readability
- Separated filter logic
- Adjusted the VideoTableModel