### PR TITLE
Use enum value for persisting and exporting settings

### DIFF
--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/library/LibraryActionType.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/library/LibraryActionType.java
@@ -1,5 +1,11 @@
 package org.lodder.subtools.multisubdownloader.lib.library;
 
+import java.util.Arrays;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum LibraryActionType {
     NOTHING("-- Maak uw keuze --"),
     RENAME("Hernoemen"),
@@ -8,23 +14,15 @@ public enum LibraryActionType {
 
     private final String description;
 
-    LibraryActionType(String description) {
-        this.description = description;
-    }
-
     @Override
     public String toString() {
         return this.description;
     }
 
+    @Deprecated(since = "Settings version 2")
     public static LibraryActionType fromString(String description) {
-        if (description != null) {
-            for (LibraryActionType action : LibraryActionType.values()) {
-                if (description.equalsIgnoreCase(action.toString())) {
-                    return action;
-                }
-            }
-        }
-        return LibraryActionType.NOTHING;
+        return Arrays.stream(LibraryActionType.values())
+                .filter(v -> description.equalsIgnoreCase(v.toString())).findAny()
+                .orElse(LibraryActionType.NOTHING);
     }
 }

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/library/LibraryOtherFileActionType.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/lib/library/LibraryOtherFileActionType.java
@@ -1,28 +1,29 @@
 package org.lodder.subtools.multisubdownloader.lib.library;
 
+import java.util.Arrays;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum LibraryOtherFileActionType {
-    NOTHING("-- Maak uw keuze --"), REMOVE("Verwijderen"), RENAME("Hernoemen"), MOVE("Verplaatsen"), MOVEANDRENAME(
-            "Verplaats en Hernoemen");
+    NOTHING("-- Maak uw keuze --"),
+    REMOVE("Verwijderen"),
+    RENAME("Hernoemen"),
+    MOVE("Verplaatsen"),
+    MOVEANDRENAME("Verplaats en Hernoemen");
 
     private final String description;
-
-    LibraryOtherFileActionType(String description) {
-        this.description = description;
-    }
 
     @Override
     public String toString() {
         return this.description;
     }
 
+    @Deprecated(since = "Settings version 2")
     public static LibraryOtherFileActionType fromString(String description) {
-        if (description != null) {
-            for (LibraryOtherFileActionType action : LibraryOtherFileActionType.values()) {
-                if (description.equalsIgnoreCase(action.toString())) {
-                    return action;
-                }
-            }
-        }
-        return LibraryOtherFileActionType.NOTHING;
+        return Arrays.stream(LibraryOtherFileActionType.values())
+                .filter(v -> description.equalsIgnoreCase(v.toString())).findAny()
+                .orElse(LibraryOtherFileActionType.NOTHING);
     }
 }

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/settings/SettingValue.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/settings/SettingValue.java
@@ -2,6 +2,7 @@ package org.lodder.subtools.multisubdownloader.settings;
 
 import java.io.File;
 import java.time.LocalDate;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.function.BiConsumer;
@@ -80,10 +81,10 @@ public enum SettingValue {
     EPISODE_LIBRARY_BACKUP_SUBTITLE_PATH(new File(""), File::getAbsolutePath, File::new, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::getLibraryBackupSubtitlePath, LibrarySettings::setLibraryBackupSubtitlePath),
     EPISODE_LIBRARY_BACKUP_SUBTITLE(false, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::isLibraryBackupSubtitle, LibrarySettings::setLibraryBackupSubtitle),
     EPISODE_LIBRARY_BACKUP_USE_WEBSITE_FILE_NAME(false, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::isLibraryBackupUseWebsiteFileName, LibrarySettings::setLibraryBackupUseWebsiteFileName),
-    EPISODE_LIBRARY_ACTION(LibraryActionType.NOTHING, LibraryActionType::toString, LibraryActionType::fromString, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::getLibraryAction, LibrarySettings::setLibraryAction),
+    EPISODE_LIBRARY_ACTION(LibraryActionType.NOTHING, LibraryActionType::name, LibraryActionType::valueOf, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::getLibraryAction, LibrarySettings::setLibraryAction),
     EPISODE_LIBRARY_USE_T_V_D_B_NAMING(false, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::isLibraryUseTVDBNaming, LibrarySettings::setLibraryUseTVDBNaming),
     EPISODE_LIBRARY_REPLACE_CHARS(false, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::isLibraryReplaceChars, LibrarySettings::setLibraryReplaceChars),
-    EPISODE_LIBRARY_OTHER_FILE_ACTION(LibraryOtherFileActionType.NOTHING, LibraryOtherFileActionType::toString, LibraryOtherFileActionType::fromString, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::getLibraryOtherFileAction, LibrarySettings::setLibraryOtherFileAction),
+    EPISODE_LIBRARY_OTHER_FILE_ACTION(LibraryOtherFileActionType.NOTHING, LibraryOtherFileActionType::name, LibraryOtherFileActionType::valueOf, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::getLibraryOtherFileAction, LibrarySettings::setLibraryOtherFileAction),
     EPISODE_LIBRARY_FOLDER(new File(""), File::getAbsolutePath, File::new, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::getLibraryFolder, LibrarySettings::setLibraryFolder),
     EPISODE_LIBRARY_STRUCTURE("", sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::getLibraryFolderStructure, LibrarySettings::setLibraryFolderStructure),
     EPISODE_LIBRARY_REMOVE_EMPTY_FOLDERS(false, sCtr -> sCtr.getSettings().getEpisodeLibrarySettings(), LibrarySettings::isLibraryRemoveEmptyFolders, LibrarySettings::setLibraryRemoveEmptyFolders),
@@ -100,10 +101,10 @@ public enum SettingValue {
     MOVIE_LIBRARY_BACKUP_SUBTITLE_PATH(new File(""), File::getAbsolutePath, File::new, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::getLibraryBackupSubtitlePath, LibrarySettings::setLibraryBackupSubtitlePath),
     MOVIE_LIBRARY_BACKUP_SUBTITLE(false, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::isLibraryBackupSubtitle, LibrarySettings::setLibraryBackupSubtitle),
     MOVIE_LIBRARY_BACKUP_USE_WEBSITE_FILE_NAME(false, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::isLibraryBackupUseWebsiteFileName, LibrarySettings::setLibraryBackupUseWebsiteFileName),
-    MOVIE_LIBRARY_ACTION(LibraryActionType.NOTHING, LibraryActionType::toString, LibraryActionType::fromString, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::getLibraryAction, LibrarySettings::setLibraryAction),
+    MOVIE_LIBRARY_ACTION(LibraryActionType.NOTHING, LibraryActionType::name, LibraryActionType::valueOf, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::getLibraryAction, LibrarySettings::setLibraryAction),
     MOVIE_LIBRARY_USE_T_V_D_B_NAMING(false, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::isLibraryUseTVDBNaming, LibrarySettings::setLibraryUseTVDBNaming),
     MOVIE_LIBRARY_REPLACE_CHARS(false, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::isLibraryReplaceChars, LibrarySettings::setLibraryReplaceChars),
-    MOVIE_LIBRARY_OTHER_FILE_ACTION(LibraryOtherFileActionType.NOTHING, LibraryOtherFileActionType::toString, LibraryOtherFileActionType::fromString, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::getLibraryOtherFileAction, LibrarySettings::setLibraryOtherFileAction),
+    MOVIE_LIBRARY_OTHER_FILE_ACTION(LibraryOtherFileActionType.NOTHING, LibraryOtherFileActionType::name, LibraryOtherFileActionType::valueOf, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::getLibraryOtherFileAction, LibrarySettings::setLibraryOtherFileAction),
     MOVIE_LIBRARY_FOLDER(new File(""), File::getAbsolutePath, File::new, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::getLibraryFolder, LibrarySettings::setLibraryFolder),
     MOVIE_LIBRARY_STRUCTURE("", sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::getLibraryFolderStructure, LibrarySettings::setLibraryFolderStructure),
     MOVIE_LIBRARY_REMOVE_EMPTY_FOLDERS(false, sCtr -> sCtr.getSettings().getMovieLibrarySettings(), LibrarySettings::isLibraryRemoveEmptyFolders, LibrarySettings::setLibraryRemoveEmptyFolders),
@@ -213,7 +214,7 @@ public enum SettingValue {
         };
     }
 
-    private String getKey() {
+    public String getKey() {
         return CaseUtils.toCamelCase(name(), true, '_');
     }
 
@@ -227,5 +228,9 @@ public enum SettingValue {
 
     protected static String getDelimiter() {
         return "[==]";
+    }
+
+    public static void loadAll(SettingsControl settingsControl, Preferences preferences) {
+        Arrays.stream(SettingValue.values()).forEach(sv -> sv.load(settingsControl, preferences));
     }
 }

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/settings/SettingsControl.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/settings/SettingsControl.java
@@ -16,6 +16,8 @@ import java.util.prefs.Preferences;
 import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.lodder.subtools.multisubdownloader.lib.library.LibraryActionType;
+import org.lodder.subtools.multisubdownloader.lib.library.LibraryOtherFileActionType;
 import org.lodder.subtools.multisubdownloader.settings.model.Settings;
 import org.lodder.subtools.multisubdownloader.settings.model.SettingsExcludeItem;
 import org.lodder.subtools.multisubdownloader.settings.model.SettingsExcludeType;
@@ -71,7 +73,7 @@ public class SettingsControl {
 
     public void load() {
         migrateSettings();
-        Arrays.stream(SettingValue.values()).forEach(sv -> sv.load(this, preferences));
+        SettingValue.loadAll(this, preferences);
         updateProxySettings();
     }
 
@@ -121,6 +123,10 @@ public class SettingsControl {
             migrateSettingsV0ToV1();
             settings = new Settings();
             state = new State();
+            SettingValue.loadAll(this, preferences);
+        }
+        if (version == 1) {
+            migrateSettingsV1ToV2();
         }
     }
 
@@ -180,6 +186,28 @@ public class SettingsControl {
         }
 
         settings.setSettingsVersion(1);
+        SETTINGS_VERSION.store(this, preferences);
+    }
+
+    @SuppressWarnings("deprecation")
+    public void migrateSettingsV1ToV2() {
+        settings.getEpisodeLibrarySettings()
+                .setLibraryOtherFileAction(LibraryOtherFileActionType.fromString(preferences.get(EPISODE_LIBRARY_OTHER_FILE_ACTION.getKey(), "")));
+        EPISODE_LIBRARY_OTHER_FILE_ACTION.store(this, preferences);
+
+        settings.getMovieLibrarySettings()
+                .setLibraryOtherFileAction(LibraryOtherFileActionType.fromString(preferences.get(MOVIE_LIBRARY_OTHER_FILE_ACTION.getKey(), "")));
+        MOVIE_LIBRARY_OTHER_FILE_ACTION.store(this, preferences);
+
+        settings.getEpisodeLibrarySettings()
+                .setLibraryAction(LibraryActionType.fromString(preferences.get(EPISODE_LIBRARY_ACTION.getKey(), "")));
+        EPISODE_LIBRARY_ACTION.store(this, preferences);
+
+        settings.getMovieLibrarySettings()
+                .setLibraryAction(LibraryActionType.fromString(preferences.get(MOVIE_LIBRARY_ACTION.getKey(), "")));
+        MOVIE_LIBRARY_ACTION.store(this, preferences);
+
+        settings.setSettingsVersion(2);
         SETTINGS_VERSION.store(this, preferences);
     }
 

--- a/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/subtitleproviders/subscene/SubsceneApi.java
+++ b/MultiSubDownloader/src/main/java/org/lodder/subtools/multisubdownloader/subtitleproviders/subscene/SubsceneApi.java
@@ -98,7 +98,7 @@ public class SubsceneApi extends Html {
                             .filter(element -> {
                                 Matcher matcher = elementNamePattern.matcher(element.text());
                                 return matcher.matches() && StringUtils.equalsIgnoreCase(matcher.group(1), serieName)
-                                        && StringUtils.equalsIgnoreCase(matcher.group(2), NUMBER_FORMAT.format(season, "%spellout-ordinal"));
+                                        && StringUtils.equalsIgnoreCase(matcher.group(2), getOrdinalName(season));
                             })
                             .map(element -> DOMAIN + element.attr("href")).findFirst();
                 } catch (ManagerException e) {


### PR DESCRIPTION
Use enum value instead of dutch description for persisting and exporting settings. This is required for localizing the application.
Old settings are migrated automatically.